### PR TITLE
Fix lodash security warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -110,9 +110,9 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "nth-check": {
       "version": "1.0.2",


### PR DESCRIPTION
`npm install` complains about potential security vulnerabilities. I understand that it probably doesn't matter for a one-off script but complaints are no fun, so let's fix this one!

Here are the complaints:

```
dev/UBC-Web-Scraper - [master●] » npm install
added 27 packages from 53 contributors and audited 42 packages in 1.68s
found 2 high severity vulnerabilities
  run `npm audit fix` to fix them, or `npm audit` for details
dev/UBC-Web-Scraper - [master●] » npm audit

                       === npm audit security report ===

# Run  npm update lodash --depth 3  to resolve 2 vulnerabilities
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Prototype Pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ lodash                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ cheerio                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ cheerio > lodash                                             │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1065                            │
└───────────────┴──────────────────────────────────────────────────────────────┘


┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Prototype Pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ lodash                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ request-promise                                              │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ request-promise > request-promise-core > lodash              │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1065                            │
└───────────────┴──────────────────────────────────────────────────────────────┘


found 2 high severity vulnerabilities in 42 scanned packages
  run `npm audit fix` to fix 2 of them.
```

I am also working on adding some command line arguments so the scraper script doesn't need to be itself changed for each session, expect a pull request for this in a bit.